### PR TITLE
Add friendly error for missing cert or key

### DIFF
--- a/compy.go
+++ b/compy.go
@@ -26,6 +26,14 @@ func main() {
 
 	p := proxy.New()
 
+	if (*ca == "") != (*caKey == "") {
+		log.Fatalln("must specify both CA certificate and key")
+	}
+
+	if (*cert == "") != (*key == "") {
+		log.Fatalln("must specify both certificate and key")
+	}
+
 	if *ca != "" {
 		if err := p.EnableMitm(*ca, *caKey); err != nil {
 			fmt.Println("not using mitm:", err)


### PR DESCRIPTION
Previously compy failed with the confusing:

`2017/01/13 15:34:38 open : no such file or directory`