### PR TITLE
Honor Accept-Encoding header in gzip transcoder

### DIFF
--- a/transcoder/gif.go
+++ b/transcoder/gif.go
@@ -3,11 +3,12 @@ package transcoder
 import (
 	"github.com/barnacs/compy/proxy"
 	"image/gif"
+	"net/http"
 )
 
 type Gif struct{}
 
-func (t *Gif) Transcode(w *proxy.ResponseWriter, r *proxy.ResponseReader) error {
+func (t *Gif) Transcode(w *proxy.ResponseWriter, r *proxy.ResponseReader, headers http.Header) error {
 	img, err := gif.Decode(r)
 	if err != nil {
 		return err

--- a/transcoder/identity.go
+++ b/transcoder/identity.go
@@ -2,10 +2,11 @@ package transcoder
 
 import (
 	"github.com/barnacs/compy/proxy"
+	"net/http"
 )
 
 type Identity struct{}
 
-func (i *Identity) Transcode(w *proxy.ResponseWriter, r *proxy.ResponseReader) error {
+func (i *Identity) Transcode(w *proxy.ResponseWriter, r *proxy.ResponseReader, headers http.Header) error {
 	return w.ReadFrom(r)
 }

--- a/transcoder/jpeg.go
+++ b/transcoder/jpeg.go
@@ -3,6 +3,7 @@ package transcoder
 import (
 	"github.com/barnacs/compy/proxy"
 	"github.com/pixiv/go-libjpeg/jpeg"
+	"net/http"
 )
 
 type Jpeg struct {
@@ -20,7 +21,7 @@ func NewJpeg(quality int) *Jpeg {
 	}
 }
 
-func (t *Jpeg) Transcode(w *proxy.ResponseWriter, r *proxy.ResponseReader) error {
+func (t *Jpeg) Transcode(w *proxy.ResponseWriter, r *proxy.ResponseReader, headers http.Header) error {
 	img, err := jpeg.Decode(r, t.decOptions)
 	if err != nil {
 		return err

--- a/transcoder/minify.go
+++ b/transcoder/minify.go
@@ -6,6 +6,7 @@ import (
 	"github.com/tdewolff/minify/css"
 	"github.com/tdewolff/minify/html"
 	"github.com/tdewolff/minify/js"
+	"net/http"
 )
 
 type Minifier struct {
@@ -24,6 +25,6 @@ func NewMinifier() *Minifier {
 	}
 }
 
-func (t *Minifier) Transcode(w *proxy.ResponseWriter, r *proxy.ResponseReader) error {
+func (t *Minifier) Transcode(w *proxy.ResponseWriter, r *proxy.ResponseReader, headers http.Header) error {
 	return t.m.Minify(r.ContentType(), w, r)
 }

--- a/transcoder/png.go
+++ b/transcoder/png.go
@@ -3,11 +3,12 @@ package transcoder
 import (
 	"github.com/barnacs/compy/proxy"
 	"image/png"
+	"net/http"
 )
 
 type Png struct{}
 
-func (t *Png) Transcode(w *proxy.ResponseWriter, r *proxy.ResponseReader) error {
+func (t *Png) Transcode(w *proxy.ResponseWriter, r *proxy.ResponseReader, headers http.Header) error {
 	img, err := png.Decode(r)
 	if err != nil {
 		return err


### PR DESCRIPTION
This avoids sending compressed data to clients which do not support
it.