### PR TITLE
Add PNG and JPEG to WebP transcoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Features:
 - gzip compression
 - transcode animated gifs to static images
 - transcode jpeg images to desired quality using libjpeg
-- transcode png images
+- transcode PNG and JPEG images to WebP
 - html/css/js minification
 
 

--- a/transcoder/jpeg.go
+++ b/transcoder/jpeg.go
@@ -2,6 +2,7 @@ package transcoder
 
 import (
 	"github.com/barnacs/compy/proxy"
+	"github.com/chai2010/webp"
 	"github.com/pixiv/go-libjpeg/jpeg"
 	"net/http"
 )
@@ -26,8 +27,19 @@ func (t *Jpeg) Transcode(w *proxy.ResponseWriter, r *proxy.ResponseReader, heade
 	if err != nil {
 		return err
 	}
-	if err = jpeg.Encode(w, img, t.encOptions); err != nil {
-		return err
+
+	if SupportsWebP(headers) {
+		options := webp.Options{
+			Lossless: false,
+			Quality:  float32(t.encOptions.Quality),
+		}
+		if err = webp.Encode(w, img, &options); err != nil {
+			return err
+		}
+	} else {
+		if err = jpeg.Encode(w, img, t.encOptions); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/transcoder/png.go
+++ b/transcoder/png.go
@@ -2,6 +2,7 @@ package transcoder
 
 import (
 	"github.com/barnacs/compy/proxy"
+	"github.com/chai2010/webp"
 	"image/png"
 	"net/http"
 )
@@ -13,8 +14,18 @@ func (t *Png) Transcode(w *proxy.ResponseWriter, r *proxy.ResponseReader, header
 	if err != nil {
 		return err
 	}
-	if err = png.Encode(w, img); err != nil {
-		return err
+
+	if SupportsWebP(headers) {
+		options := webp.Options{
+			Lossless: true,
+		}
+		if err = webp.Encode(w, img, &options); err != nil {
+			return err
+		}
+	} else {
+		if err = png.Encode(w, img); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/transcoder/util.go
+++ b/transcoder/util.go
@@ -1,0 +1,15 @@
+package transcoder
+
+import (
+	"net/http"
+	"strings"
+)
+
+func SupportsWebP(headers http.Header) bool {
+	for _, v := range strings.Split(headers.Get("Accept"), ",") {
+		if strings.SplitN(v, ";", 2)[0] == "image/webp" {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
WebP lossy mode offers up to 30% better compression than JPEG.