### PR TITLE
Fix RFC 7235 violation

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -113,7 +113,7 @@ func (p *Proxy) handle(w http.ResponseWriter, r *http.Request) error {
 	// TODO: only HTTPS?
 	if p.user != "" {
 		if !p.checkHttpBasicAuth(r.Header.Get("Proxy-Authorization")) {
-			w.Header().Set("WWW-Authenticate", "Basic realm=\"Compy\"")
+			w.Header().Set("Proxy-Authenticate", "Basic realm=\"Compy\"")
 			w.WriteHeader(http.StatusProxyAuthRequired)
 			return nil
 		}


### PR DESCRIPTION
Hi,

When an unauthorized/unauthenticated user attempts to send a request on a compy instance requiring authentication, compy sends back the ``WWW-Authenticate`` header field, instead of the expected ``Proxy-Authentication`` header field in the HTTP ``407 Proxy Authentication Required`` reply.

This behaviour violates [RFC 7235](https://tools.ietf.org/html/rfc7235#page-6), which states in section 3.2:

> The proxy MUST send a Proxy-Authenticate header field (Section 4.3) containing a challenge applicable to that proxy for the target resource.  

This is a high priority fix IMHO: a standards-compliant browser doesn't send back the authentication prompt, and lands on a blank page with the offending version.

Kind regards