### PR TITLE
[Security] Don't leak proxy credentials to target website

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -117,6 +117,7 @@ func (p *Proxy) handle(w http.ResponseWriter, r *http.Request) error {
 			w.WriteHeader(http.StatusProxyAuthRequired)
 			return nil
 		}
+		r.Header.Del("Proxy-Authorization")
 	}
 
 	if r.Method == "CONNECT" {


### PR DESCRIPTION
Hi,

In the unpatched version, the ``Proxy-Authorization`` header is leaked to the target website. This poses a security threat, as the chosen authentication scheme would enable a rogue target to get valid proxy credentials.

Moreover, as told in [RFC7235, section 4.4](https://tools.ietf.org/html/rfc7235#section-4.4): 

> Unlike Authorization, the Proxy-Authorization header field applies only to the next inbound proxy that demanded authentication using the Proxy-Authenticate field. [...] A proxy MAY relay the credentials from the client request to the next proxy if that is the mechanism by which the proxies cooperatively authenticate a given request.

Kind regards