### PR TITLE
"go git" install not working after commit 0602293

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -138,8 +138,6 @@ func (p *Proxy) handle(w http.ResponseWriter, r *http.Request) error {
 		return fmt.Errorf("error forwarding request: %s", err)
 	}
 	defer resp.Body.Close()
-	user_agent = r.Header().Get("User-Agent")
-	w.Header().Set("User-Agent", user_agent)
 	rw := newResponseWriter(w)
 	rr := newResponseReader(resp)
 	err = p.proxyResponse(rw, rr, r.Header)


### PR DESCRIPTION
There are install errors after commit [0602293](https://github.com/barnacs/compy/commit/0602293989aca45d8f2c0791273d2fcdba48342e): 
# github.com/barnacs/compy/proxy
../go/pkg/mod/github.com/barnacs/compy@v0.0.0-20211019001919-0602293989ac/proxy/proxy.go:141:2: undefined: user_agent
../go/pkg/mod/github.com/barnacs/compy@v0.0.0-20211019001919-0602293989ac/proxy/proxy.go:141:23: cannot call non-function r.Header (type http.Header)
../go/pkg/mod/github.com/barnacs/compy@v0.0.0-20211019001919-0602293989ac/proxy/proxy.go:142:31: undefined: user_agent
